### PR TITLE
Fix fsharp list schema generation

### DIFF
--- a/src/FSharp.Data.JsonSchema/JsonSchema.fs
+++ b/src/FSharp.Data.JsonSchema/JsonSchema.fs
@@ -18,7 +18,8 @@ module Reflection =
 
     let isList (y: System.Type) =
         y.IsGenericType
-        && typedefof<List<_>> = y.GetGenericTypeDefinition()
+        && (typedefof<List<_>>.Equals(y.GetGenericTypeDefinition())
+            || typedefof<list<_>>.Equals(y.GetGenericTypeDefinition()))
 
     let isOption (y: System.Type) =
         y.IsGenericType

--- a/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
+++ b/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
@@ -559,4 +559,47 @@ let tests =
 
               let actual = generator (typeof<PaginatedResult<_>>)
               "╰〳 ಠ 益 ಠೃ 〵╯" |> equal actual expected
+          }
+          
+          test "FSharp list generates proper schema" {
+              let expected = """
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "TestList",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "name": {
+      "type": "string"
+    },
+    "records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TestRecord"
+      }
+    }
+  },
+  "definitions": {
+    "TestRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+"""
+              let actual = generator typeof<TestList>
+              "╰〳 ಠ 益 ಠೃ 〵╯" |> equal actual expected 
+              printfn $"{actual.ToJson()}"
           } ]

--- a/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
+++ b/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
@@ -601,5 +601,4 @@ let tests =
 """
               let actual = generator typeof<TestList>
               "╰〳 ಠ 益 ಠೃ 〵╯" |> equal actual expected 
-              printfn $"{actual.ToJson()}"
           } ]

--- a/test/FSharp.Data.JsonSchema.Tests/TestTypes.fs
+++ b/test/FSharp.Data.JsonSchema.Tests/TestTypes.fs
@@ -6,6 +6,11 @@ type TestClass() =
 
 type TestRecord = { FirstName: string; LastName: string }
 
+type TestList =
+    { Id: int
+      Name: string
+      Records: TestRecord list }
+
 type TestEnum =
     | First = 0
     | Second = 1


### PR DESCRIPTION
Fixes #13 

- When checking if a type is a list, need to check  for `typedefof<List<_>>` and `typedefof<list<_>>`
- Added a test as well

FYI I ran these tests using .net 6.0. I'm using apple silicon and .net would not run for me.