### PR TITLE
Du decimal definitions

### DIFF
--- a/src/FSharp.Data.JsonSchema/JsonSchema.fs
+++ b/src/FSharp.Data.JsonSchema/JsonSchema.fs
@@ -24,6 +24,9 @@ module Reflection =
     let isOption (y: System.Type) =
         y.IsGenericType
         && typedefof<_ option> = y.GetGenericTypeDefinition()
+        
+    let isPrimitive (ty: Type) =
+        ty.IsPrimitive || ty = typeof<String> || ty = typeof<Decimal>
 
 type OptionSchemaProcessor() =
     static let optionTy = typedefof<option<_>>
@@ -83,7 +86,6 @@ type SingleCaseDuSchemaProcessor() =
 
 type MultiCaseDuSchemaProcessor(?casePropertyName) =
     let casePropertyName = defaultArg casePropertyName "kind"
-    let isPrimitive (ty: Type) = ty.IsPrimitive || ty = typeof<String>
 
     member this.Process(context: SchemaProcessorContext) =
         if
@@ -151,7 +153,7 @@ type MultiCaseDuSchemaProcessor(?casePropertyName) =
                                     | _ -> context.Generator.Generate(innerTy)
 
                                 let prop =
-                                    if isPrimitive innerTy then
+                                    if Reflection.isPrimitive innerTy then
                                         JsonSchemaProperty(Type = fieldSchema.Type)
                                     else
                                         if not (fieldSchemaCache.ContainsKey innerTy) then
@@ -168,8 +170,8 @@ type MultiCaseDuSchemaProcessor(?casePropertyName) =
                                     | _ -> context.Generator.Generate(field.PropertyType)
 
                                 let prop =
-                                    if isPrimitive field.PropertyType then
-                                        JsonSchemaProperty(Type = fieldSchema.Type)
+                                    if Reflection.isPrimitive field.PropertyType then
+                                        JsonSchemaProperty(Type = fieldSchema.Type, Format = fieldSchema.Format)
                                     else
                                         if not (fieldSchemaCache.ContainsKey field.PropertyType) then
                                             context.Resolver.AppendSchema(

--- a/src/FSharp.Data.JsonSchema/JsonSchema.fs
+++ b/src/FSharp.Data.JsonSchema/JsonSchema.fs
@@ -113,6 +113,7 @@ type MultiCaseDuSchemaProcessor(?casePropertyName) =
 
                         s.Enumeration.Add(case.Name)
                         s.EnumerationNames.Add(case.Name)
+                        s.AllowAdditionalProperties <- false
                         s
                     else
                         // Create the schema for the additional properties.
@@ -126,6 +127,7 @@ type MultiCaseDuSchemaProcessor(?casePropertyName) =
                         caseProp.EnumerationNames.Add(case.Name)
                         s.Properties.Add(casePropertyName, caseProp)
                         s.RequiredProperties.Add(casePropertyName)
+                        s.AllowAdditionalProperties <- false
 
                         // Add the remaining fields
                         for field in fields do
@@ -181,7 +183,6 @@ type MultiCaseDuSchemaProcessor(?casePropertyName) =
 
                                 s.Properties.Add(camelCaseFieldName, prop)
                                 s.RequiredProperties.Add(camelCaseFieldName)
-
                         s
 
                 // Attach each case definition.

--- a/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
+++ b/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
@@ -169,7 +169,8 @@ let tests =
           "enum": ["WithOneField"]
         },
         "item": {
-          "type": "integer"
+          "type": "integer",
+          "format": "int32"
         }
       }
     },
@@ -192,7 +193,8 @@ let tests =
           "type": "string"
         },
         "value": {
-          "type": "number"
+          "type": "number",
+          "format": "double"
         }
       }
     }
@@ -290,7 +292,8 @@ let tests =
               ]
             },
             "item": {
-              "type": "integer"
+              "type": "integer",
+              "format": "int32"
             }
           }
         },
@@ -317,7 +320,8 @@ let tests =
               "type": "string"
             },
             "value": {
-              "type": "number"
+              "type": "number",
+              "format": "double"
             }
           }
         }
@@ -613,4 +617,74 @@ let tests =
 """
               let actual = generator typeof<TestList>
               "╰〳 ಠ 益 ಠೃ 〵╯" |> equal actual expected 
+          }
+          test "FSharp decimal generates correct schema" {
+            let expected = """
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "TestDecimal",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "test": {
+      "$ref": "#/definitions/DuWithDecimal"
+    },
+    "total": {
+      "type": "number",
+      "format": "decimal"
+    }
+  },
+  "definitions": {
+    "DuWithDecimal": {
+      "definitions": {
+        "Nothing": {
+          "type": "string",
+          "default": "Nothing",
+          "additionalProperties": false,
+          "x-enumNames": [
+            "Nothing"
+          ],
+          "enum": [
+            "Nothing"
+          ]
+        },
+        "Amount": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "tag",
+            "item"
+          ],
+          "properties": {
+            "tag": {
+              "type": "string",
+              "default": "Amount",
+              "x-enumNames": [
+                "Amount"
+              ],
+              "enum": [
+                "Amount"
+              ]
+            },
+            "item": {
+              "type": "number",
+              "format": "decimal"
+            }
+          }
+        }
+      },
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DuWithDecimal/definitions/Nothing"
+        },
+        {
+          "$ref": "#/definitions/DuWithDecimal/definitions/Amount"
+        }
+      ]
+    }
+  }
+}
+"""
+            let actual = generator typeof<TestDecimal>
+            "╰〳 ಠ 益 ಠೃ 〵╯" |> equal actual expected
           } ]

--- a/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
+++ b/test/FSharp.Data.JsonSchema.Tests/GeneratorTests.fs
@@ -150,11 +150,13 @@ let tests =
     "Case": {
       "type": "string",
       "default": "Case",
+      "additionalProperties": false,
       "x-enumNames": ["Case"],
       "enum": ["Case"]
     },
     "WithOneField": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag",
         "item"
@@ -173,6 +175,7 @@ let tests =
     },
     "WithNamedFields": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag",
         "name",
@@ -233,6 +236,7 @@ let tests =
     },
     "Rec": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag",
         "item"
@@ -259,6 +263,7 @@ let tests =
         "Case": {
           "type": "string",
           "default": "Case",
+          "additionalProperties": false,
           "x-enumNames": [
             "Case"
           ],
@@ -268,6 +273,7 @@ let tests =
         },
         "WithOneField": {
           "type": "object",
+          "additionalProperties": false,
           "required": [
             "tag",
             "item"
@@ -290,6 +296,7 @@ let tests =
         },
         "WithNamedFields": {
           "type": "object",
+          "additionalProperties": false,
           "required": [
             "tag",
             "name",
@@ -329,6 +336,7 @@ let tests =
     },
     "Du": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag",
         "item"
@@ -366,6 +374,7 @@ let tests =
     },
     "SingleDu": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag",
         "item"
@@ -403,6 +412,7 @@ let tests =
     },
     "Enum": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag",
         "item"
@@ -438,6 +448,7 @@ let tests =
     },
     "Class": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag",
         "item"
@@ -460,6 +471,7 @@ let tests =
     },
     "Opt": {
       "type": "object",
+      "additionalProperties": false,
       "required": [
         "tag"
       ],

--- a/test/FSharp.Data.JsonSchema.Tests/TestTypes.fs
+++ b/test/FSharp.Data.JsonSchema.Tests/TestTypes.fs
@@ -35,6 +35,14 @@ type Nested =
     | Class of TestClass
     | Opt of TestRecord option
 
+type DuWithDecimal =
+    | Nothing
+    | Amount of decimal
+
+type TestDecimal =
+    { Test: DuWithDecimal
+      Total: decimal }
+
 type RecWithOption =
     { Name: string
       Description: string option }


### PR DESCRIPTION
Fixes #18

- Decimals are considered primitive types
- Primitives inside a DU will include their 'format'
- Added test